### PR TITLE
Remove duplicate declaration of mobf_trader object

### DIFF
--- a/mob_basics.lua
+++ b/mob_basics.lua
@@ -573,7 +573,6 @@ end
 -- compatibility function for random_buildings
 mobf_trader_spawn_trader = mob_basics.spawn_mob;
 
-mobf_trader = {};
 mobf_trader.spawn_trader = mob_basics.spawn_mob;
 
 


### PR DESCRIPTION
This pull removes the line
    mobf_trader = {};
from mob_basics.lua as it overwrites the default vars defined in init.lua when this file is loaded, causing them to be 'nil' when accessed later in init.lua
